### PR TITLE
safety around getting out of band upgrade request

### DIFF
--- a/polling/client.go
+++ b/polling/client.go
@@ -2,6 +2,7 @@ package polling
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -75,6 +76,9 @@ func (c *client) NextReader() (*parser.PacketDecoder, error) {
 }
 
 func (c *client) NextWriter(messageType message.MessageType, packetType parser.PacketType) (io.WriteCloser, error) {
+	if c == nil {
+		return nil, errors.New("client.NextWriter with nil client")
+	}
 	if c.state != stateNormal {
 		return nil, io.EOF
 	}

--- a/polling/server.go
+++ b/polling/server.go
@@ -2,6 +2,7 @@ package polling
 
 import (
 	"bytes"
+	"errors"
 	"html/template"
 	"io"
 	"net/http"
@@ -74,6 +75,9 @@ func (p *Polling) Close() error {
 }
 
 func (p *Polling) NextWriter(msgType message.MessageType, packetType parser.PacketType) (io.WriteCloser, error) {
+	if p == nil {
+		return nil, errors.New("polling.NextWriter() with nil polling")
+	}
 	if p.getState() != stateNormal {
 		return nil, io.EOF
 	}

--- a/server_conn.go
+++ b/server_conn.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"sync"
 	"time"
@@ -351,7 +352,7 @@ func (c *serverConn) upgraded() {
 	// both current and upgrading to nil
 	if c.upgrading == nil {
 		// should print a log here, but there is no logger accessible
-		log.
+		log.Println(time.Now(), "double upgrade from", c.request.RemoteAddr)
 		return
 	}
 	c.transportLocker.Lock()

--- a/server_conn.go
+++ b/server_conn.go
@@ -135,7 +135,7 @@ func (c *serverConn) NextReader() (MessageType, io.ReadCloser, error) {
 func (c *serverConn) NextWriter(t MessageType) (io.WriteCloser, error) {
 	// just to be sure
 	if c == nil {
-		return nil, fmt.Errorf("called nextWriter on nil serverConn NOT HEALTHY")
+		return nil, fmt.Errorf("called nextWriter on nil serverConn")
 	}
 	switch c.getState() {
 	case stateUpgrading:
@@ -154,7 +154,7 @@ func (c *serverConn) NextWriter(t MessageType) (io.WriteCloser, error) {
 	}
 	c.writerLocker.Lock()
 	if curr := c.getCurrent(); curr == nil {
-		return nil, fmt.Errorf("current is nil, NOT HEALTHY")
+		return nil, fmt.Errorf("current socket is nil")
 	}
 	// we got a crash that looks like this
 	// (*serverConn).NextWriter(0xc42161fc70, 0x0, 0xc42462fcb0, 0x403355, 0xc420b90960, 0xc42462fcd0)
@@ -352,6 +352,7 @@ func (c *serverConn) upgraded() {
 	// prevent double upgrade from crashing NextWriter() due to setting
 	// both current and upgrading to nil
 	if c.upgrading == nil {
+		// should print a log here, but there is no logger accessible
 		c.transportLocker.Unlock()
 		return
 	}

--- a/server_conn.go
+++ b/server_conn.go
@@ -133,9 +133,8 @@ func (c *serverConn) NextReader() (MessageType, io.ReadCloser, error) {
 }
 
 func (c *serverConn) NextWriter(t MessageType) (io.WriteCloser, error) {
-	// just to be sure
 	if c == nil {
-		return nil, fmt.Errorf("called nextWriter on nil serverConn")
+		return nil, errors.New("serverConn.NextWriter() with nil serverConn")
 	}
 	switch c.getState() {
 	case stateUpgrading:
@@ -348,14 +347,14 @@ func (c *serverConn) setUpgrading(name string, s transport.Server) {
 }
 
 func (c *serverConn) upgraded() {
-	c.transportLocker.Lock()
 	// prevent double upgrade from crashing NextWriter() due to setting
 	// both current and upgrading to nil
 	if c.upgrading == nil {
 		// should print a log here, but there is no logger accessible
-		c.transportLocker.Unlock()
+		log.
 		return
 	}
+	c.transportLocker.Lock()
 	current := c.current
 	c.current = c.upgrading
 	c.currentName = c.upgradingName

--- a/server_conn.go
+++ b/server_conn.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"sync"
 	"time"
@@ -351,8 +350,6 @@ func (c *serverConn) upgraded() {
 	// prevent double upgrade from crashing NextWriter() due to setting
 	// both current and upgrading to nil
 	if c.upgrading == nil {
-		// should print a log here, but there is no logger accessible
-		log.Println(time.Now(), "double upgrade from", c.request.RemoteAddr)
 		return
 	}
 	c.transportLocker.Lock()

--- a/server_conn.go
+++ b/server_conn.go
@@ -349,7 +349,8 @@ func (c *serverConn) setUpgrading(name string, s transport.Server) {
 
 func (c *serverConn) upgraded() {
 	c.transportLocker.Lock()
-	//  prevent double upgrade from killing the connection
+	// prevent double upgrade from crashing NextWriter() due to setting
+	// both current and upgrading to nil
 	if c.upgrading == nil {
 		c.transportLocker.Unlock()
 		return

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -1,6 +1,7 @@
 package websocket
 
 import (
+	"errors"
 	"io"
 	"net/http"
 
@@ -51,6 +52,9 @@ func (c *client) NextReader() (*parser.PacketDecoder, error) {
 }
 
 func (c *client) NextWriter(msgType message.MessageType, packetType parser.PacketType) (io.WriteCloser, error) {
+	if c == nil {
+		return nil, errors.New("client.NextWriter() on nil client")
+	}
 	wsType, newEncoder := websocket.TextMessage, parser.NewStringEncoder
 	if msgType == message.MessageBinary {
 		wsType, newEncoder = websocket.BinaryMessage, parser.NewBinaryEncoder

--- a/websocket/server.go
+++ b/websocket/server.go
@@ -1,6 +1,7 @@
 package websocket
 
 import (
+	"errors"
 	"io"
 	"net/http"
 
@@ -50,6 +51,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) NextWriter(msgType message.MessageType, packetType parser.PacketType) (io.WriteCloser, error) {
+	if s == nil {
+		return nil, errors.New("server.NextWriter() on nil server")
+	}
 	wsType, newEncoder := websocket.TextMessage, parser.NewStringEncoder
 	if msgType == message.MessageBinary {
 		wsType, newEncoder = websocket.BinaryMessage, parser.NewBinaryEncoder


### PR DESCRIPTION
Simplified PR that just focuses on the nil ptr issue.

Crashing because `getCurrent()` is returning nil

This can happen if we receive an out of band UPGRADE from a client.

Logic  in `upgraded()` function, can end up setting both "current" and "upgrading" to nil