### PR TITLE
its possible for the ping chan to be closed outside of the locks

### DIFF
--- a/server_conn.go
+++ b/server_conn.go
@@ -78,7 +78,6 @@ type serverConn struct {
 	pingTimeout     time.Duration
 	pingInterval    time.Duration
 	pingChan        chan bool
-	//pingLocker      sync.Mutex
 }
 
 var InvalidError = errors.New("invalid transport")
@@ -224,8 +223,6 @@ func (c *serverConn) OnPacket(r *parser.PacketDecoder) {
 		c.writerLocker.Unlock()
 		fallthrough
 	case parser.PONG:
-		//c.pingLocker.Lock()
-		//defer c.pingLocker.Unlock()
 		if s := c.getState(); s != stateNormal && s != stateUpgrading {
 			return
 		}
@@ -270,9 +267,7 @@ func (c *serverConn) OnClose(server transport.Server) {
 	}
 	c.setState(stateClosed)
 	safeRun(func() { close(c.readerChan) })
-	//c.pingLocker.Lock()
 	safeRun(func() { close(c.pingChan) })
-	//c.pingLocker.Unlock()
 	c.callback.onClose(c.id)
 }
 

--- a/server_conn_test.go
+++ b/server_conn_test.go
@@ -205,6 +205,8 @@ func TestConn(t *testing.T) {
 
 			err = conn.Close()
 			So(err, ShouldBeNil)
+			err = conn.Close()
+			So(err, ShouldBeNil)
 
 			time.Sleep(time.Second)
 

--- a/server_conn_test.go
+++ b/server_conn_test.go
@@ -203,6 +203,7 @@ func TestConn(t *testing.T) {
 			So(server.closed[id], ShouldEqual, 1)
 			server.closedLocker.Unlock()
 
+			// test double close
 			err = conn.Close()
 			So(err, ShouldBeNil)
 			err = conn.Close()


### PR DESCRIPTION
Simple fix, but difficult to reason about.

Here is what I think has happened to lead to this panic :  

1 - We get a PONG packet, and then call the OnPacket() handler.

2 - Around the same time, the socket has been dropped.  The OnClose() handler gets called.

3 - Goroutine scheduler fights it out, OnClose() wins.  The pingChan is closed.

4 - OnPacket() now gets scheduled, it goes to write a Ping to the closed pingChan - boom


----------

This fix removes the pingLocker altogether (because its making bad assumptions, and will never really work in this edge case) . ... and just does an unlocked write to the pingChan, using the magic of select to  gracefully handle the case where the pingChan is dead.

Looks like thats the whole reason for the pingLocker mutex being added in the first place ... that was a bad move as it turns out. 